### PR TITLE
Customize tcpdump to filter specific traffic

### DIFF
--- a/code4yo_com.ipynb
+++ b/code4yo_com.ipynb
@@ -168,6 +168,56 @@
         "\n",
         "logger.info('Monitoring network activity...')"
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "customizing-tcpdump",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Customizing tcpdump to Filter Specific Traffic"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "tcpdump-filter-code",
+        "colab_type": "code"
+      },
+      "outputs": [],
+      "source": [
+        "# Example code to filter traffic by host, port, and protocol using tcpdump\n",
+        "!tcpdump -i any host 192.168.1.1\n",
+        "!tcpdump -i any port 80\n",
+        "!tcpdump -i any tcp"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "combining-filters",
+        "colab_type": "text"
+      },
+      "source": [
+        "## Combining Filters in tcpdump"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "tcpdump-combine-filters-code",
+        "colab_type": "code"
+      },
+      "outputs": [],
+      "source": [
+        "# Example code to combine multiple filters using logical operators in tcpdump\n",
+        "!tcpdump -i any host 192.168.1.1 and port 80\n",
+        "!tcpdump -i any tcp or udp\n",
+        "!tcpdump -i any not port 22"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Add customization for `tcpdump` to filter specific traffic in `code4yo_com.ipynb`.

* Add a markdown cell with the title "Customizing tcpdump to Filter Specific Traffic".
* Add a code cell to demonstrate filtering traffic by host, port, and protocol using `tcpdump`.
* Add a markdown cell with the title "Combining Filters in tcpdump".
* Add a code cell to demonstrate combining multiple filters using logical operators in `tcpdump`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/..github/pull/4?shareId=90c2f23d-56e0-480d-92ce-b865c90e355f).